### PR TITLE
Add support for Moes thermostat WHT-009

### DIFF
--- a/custom_components/tuya_local/devices/moes_wht009_thermostat.yaml
+++ b/custom_components/tuya_local/devices/moes_wht009_thermostat.yaml
@@ -1,0 +1,235 @@
+name: Moes thermostat WHT-009
+products:
+  - id: 14bmxdarlb4ravgd
+    name: Moes thermostat WHT-009
+primary_entity:
+  entity: climate
+  dps:
+    - id: 1
+      name: hvac_mode
+      type: boolean
+      mapping:
+        - dps_val: false
+          value: "off"
+        - dps_val: true
+          value: heat
+    - id: 2
+      name: preset_mode
+      type: string
+      mapping:
+        - dps_val: manual
+          value: Manual
+        - dps_val: auto
+          value: Auto
+    - id: 16
+      name: temperature
+      type: integer
+      unit: C
+      range:
+        min: 50
+        max: 450
+      mapping:
+        - scale: 10
+          step: 5
+    - id: 24
+      name: current_temperature
+      type: integer
+      mapping:
+        - scale: 10
+          step: 5
+    - id: 19
+      type: integer
+      name: max_temperature
+      mapping:
+        - scale: 10
+    - id: 26
+      type: integer
+      name: min_temperature
+      mapping:
+        - scale: 10
+    - id: 36
+      type: string
+      name: hvac_action
+      mapping:
+        - dps_val: open
+          value: heating
+        - dps_val: close
+          value: idle
+    - id: 71
+      type: string
+      optional: true
+      name: week_program
+
+secondary_entities:
+  - entity: switch
+    translation_key: eco_mode
+    name: Eco mode
+    category: config
+    icon: "mdi:leaf"
+    dps:
+      - id: 4
+        type: boolean
+        entity: switch
+  - entity: number
+    name: Maximum temperature
+    class: temperature
+    category: config
+    icon: "mdi:thermometer-chevron-up"
+    dps:
+      - id: 19
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        range:
+          min: 150
+          max: 450
+        mapping:
+          - scale: 10
+            step: 10
+  - entity: sensor
+    name: Current temperature
+    class: temperature
+    dps:
+      - id: 24
+        type: integer
+        name: sensor
+        class: measurement
+        unit: C
+        mapping:
+          - scale: 10
+            step: 5
+  - entity: number
+    name: Minimum temperature
+    class: temperature
+    category: config
+    icon: "mdi:thermometer-chevron-down"
+    dps:
+      - id: 26
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        range:
+          min: 50
+          max: 150
+        mapping:
+          - scale: 10
+            step: 10
+  - entity: number
+    name: Temperature correction
+    category: config
+    icon: "mdi:thermometer-check"
+    dps:
+      - id: 27
+        type: integer
+        optional: true
+        name: value
+        range:
+          min: -9
+          max: 9
+  - entity: sensor
+    name: Hvac action
+    dps:
+      - id: 36
+        type: string
+        name: sensor
+  - entity: lock
+    translation_key: child_lock
+    category: config
+    dps:
+      - id: 40
+        type: boolean
+        name: lock
+  - entity: sensor
+    name: External temperature
+    class: temperature
+    dps:
+      - id: 101
+        type: integer
+        name: sensor
+        class: measurement
+        unit: C
+        mapping:
+          - scale: 10
+            step: 5
+  - entity: select
+    name: Temperature sensor type
+    icon: "mdi:home-thermometer"
+    category: config
+    dps:
+      - id: 102
+        type: string
+        optional: true
+        name: option
+        mapping:
+          - dps_val: IN
+            value: Internal
+          - dps_val: OU
+            value: External
+          - dps_val: AL
+            value: Both
+  - entity: number
+    name: Temperature hysteresis
+    category: config
+    icon: "mdi:thermometer-plus"
+    dps:
+      - id: 103
+        type: integer
+        optional: true
+        name: value
+        unit: °
+        range:
+          min: 1
+          max: 5
+  - entity: number
+    name: High protection temperature setting
+    class: temperature
+    category: config
+    icon: "mdi:thermometer-chevron-up"
+    dps:
+      - id: 104
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        range:
+          min: 100
+          max: 700
+        mapping:
+          - scale: 10
+            step: 10
+  - entity: number
+    name: Low protection temperature setting
+    class: temperature
+    category: config
+    icon: "mdi:thermometer-chevron-down"
+    dps:
+      - id: 105
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        range:
+          min: 0
+          max: 100
+        mapping:
+          - scale: 10
+            step: 10
+  - entity: number
+    name: Eco mode temperature setting
+    class: temperature
+    category: config
+    icon: "mdi:leaf"
+    dps:
+      - id: 106
+        type: integer
+        name: value
+        optional: true
+        unit: C
+        range:
+          min: 0
+          max: 300
+        mapping:
+          - scale: 10
+            step: 10


### PR DESCRIPTION
### Product name:
Moes BHT-009 Smart Knob Thermostat

### Where to buy:
https://moeshouse.com/products/wifi-programmable-thermostat-room-temperature-controller-for-water-electric-gas-boiler-floor-heating

### Product ID:
14bmxdarlb4ravgd

### dps
```
"codes": {
    "1": "Switch",
    "2": "Mode",
    "3": "Working status",
    "4": "Eco mode",
    "16": "Set temperature",
    "18": "Max. set temp. -℉",
    "19": "Max. set temp.",
    "20": "Min. setting temp. -℉",
    "24": "Current temperature",
    "26": "Min. setting temp.",
    "27": "Temp. compensation",
    "36": "Output state",
    "40": "Child lock",
    "71": "Week Program",
    "101": "Floor temp.",
    "102": "Sensor type",
    "103": "Dead zone temp.",
    "104": "High protection temp. setting",
    "105": "Low protection temp. setting",
    "106": "Eco mode temp. setting"
}
```
### Screenshot:
<img width="817" alt="Screenshot 2024-10-28 at 22 42 59" src="https://github.com/user-attachments/assets/7aa59d73-5d5b-4ec9-9103-8a8f7e926681">